### PR TITLE
add title tag and fix syntax issues

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -1,25 +1,27 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 
 <head>
-	<meta charset="utf-8">
+	<meta charset="utf-8"/>
+	<title>LangServer.org</title>
+
 	<!-- jQuery -->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 
 	<!-- Latest compiled and minified CSS -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
-		crossorigin="anonymous">
+		crossorigin="anonymous"/>
 
 	<!-- Optional theme -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp"
-		crossorigin="anonymous">
+		crossorigin="anonymous"/>
 
 	<!-- Latest compiled and minified JavaScript -->
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
 		crossorigin="anonymous"></script>
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
 
-	<link rel="stylesheet" href="./style-additions.css">
+	<link rel="stylesheet" href="./style-additions.css"/>
 
 	<!-- GA -->
 	<script>
@@ -68,7 +70,7 @@
 
 		<br/>
 		<h3>Why LSP?</h3>
-		</p>
+		<p>
 		LSP creates the opportunity to reduce the <em>m-times-n</em> complexity problem of providing a high level of support for
 		any programming language in any editor, IDE, or client endpoint to a simpler <em>m-plus-n</em> problem.
 		</p>
@@ -87,7 +89,8 @@
 				<div class="panel panel-default">
 					<div class="panel-heading">
 						<h3 class="panel-title text-center">
-							<u>The problem</u>: "The Matrix"</h3>
+							<u>The problem</u>: "The Matrix"
+						</h3>
 					</div>
 				</div>
 
@@ -198,14 +201,12 @@
 		</p>
 		<br/>
 		<h4>Qualifications:</h4>
-		<p>
-			To be included on this list, language servers and clients must:
-			<ol>
-				<li>be fully open source</li>
-				<li>be editor- or language-agnostic (for language servers and clients, respectively)</li>
-				<li>implement at least one of the key methods listed below</li>
-			</ol>
-		</p>
+		<p>To be included on this list, language servers and clients must:</p>
+		<ul>
+			<li>be fully open source</li>
+			<li>be editor- or language-agnostic (for language servers and clients, respectively)</li>
+			<li>implement at least one of the key methods listed below</li>
+		</ul>
 		<p>
 			Think we're missing something? <a href="https://github.com/langserver/langserver.github.io">Let us know</a>!
 		</p>
@@ -237,7 +238,7 @@
 		<table class="table table-striped">
 			<thead>
 				<th>Language</th>
-				<th>Maintainer&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</th>
+				<th>Maintainer&#160;&#160;&#160;&#160;&#160;&#160;</th>
 				<th class="repo">Repository</th>
 				<th>Code completion</th>
 				<th>Hover</th>
@@ -431,8 +432,8 @@
 				<td class=""></td>
 			</tr>
 			<tr>
-        <th>Python</th>
-        <td><a href="http://www.palantir.com/">Palantir</a></td>
+				<th>Python</th>
+				<td><a href="http://www.palantir.com/">Palantir</a></td>
 				<td class="repo"><a href="https://github.com/palantir/python-language-server">github.com/palantir/python-language-server</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
@@ -528,7 +529,7 @@
 		<table class="table table-striped">
 			<thead>
 				<th>Editor/client</th>
-				<th>Maintainer&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</th>
+				<th>Maintainer&#160;&#160;&#160;&#160;&#160;&#160;</th>
 				<th>Repository</th>
 				<th>Code completion</th>
 				<th>Hover</th>
@@ -582,7 +583,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>
-				<th colspan="9"><br/>Works in progress</td>
+				<th colspan="9"><br/>Works in progress</th>
 			</tr>
 			<tr>
 				<th>Emacs</th>

--- a/index.xhtml
+++ b/index.xhtml
@@ -3,7 +3,7 @@
 
 <head>
 	<meta charset="utf-8"/>
-	<title>LangServer.org</title>
+	<title>Langserver.org</title>
 
 	<!-- jQuery -->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>


### PR DESCRIPTION
- Without the title, browser tabs show the full url, including the protocol: `http://langserver.org/`
- Whitespace has been adjusted (spaces vs. tabs, line breaks, etc.)
- Additionally, the source was made polyglot (simultaneously valid html5 and xhtml: http://www.w3.org/TR/html-polyglot/), which allows such syntax issues to be immediately detected by the browser. Some of the issues fixed in this PR were identified thanks to this change:
    - mismatched tags;
    - unclosed tags
    - invalid tag nesting (`<ol>` inside `<p>`, which only supports inline content)