### PR TITLE
Add the Dockerfile language server

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,18 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>
+				<th>Dockerfile</th>
+				<td><a href="https://github.com/rcjsuen">Remy Suen</a></td>
+				<td class="repo"><a href="https://github.com/rcjsuen/dockerfile-language-server-nodejs">github.com/rcjsuen/dockerfile-language-server-nodejs</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
+				<td class="danger"></td>
+				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			</tr>
+			<tr>
 				<th>Go</th>
 				<td><a href="https://sourcegraph.com/">Sourcegraph</a></td>
 				<td class="repo"><a href="https://github.com/sourcegraph/go-langserver">github.com/sourcegraph/go-langserver</a></td>


### PR DESCRIPTION
Hi, I've created a language server for Dockerfiles.

It is open source and hosted on [GitHub](https://github.com/rcjsuen/dockerfile-language-server-nodejs) and can be installed through [npm](https://www.npmjs.com/package/dockerfile-language-server-nodejs). It will be used by the next release of the [vscode-docker](https://github.com/Microsoft/vscode-docker/commit/dcd9a365fc5b0b525a9b5d94a8af823fe2b4a6ad#diff-4ac32a78649ca5bdd8e0ba38b7006a1e) VS Code extension.