### PR TITLE
Update reference to MS JSON language server

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,7 +388,7 @@
 			<tr>
 				<th>JSON</th>
 				<td><a href="https://www.microsoft.com/">Microsoft</a></td>
-				<td class="repo"><a href="https://github.com/Microsoft/vscode/tree/master/extensions/json">github.com/Microsoft/vscode/tree/master/extensions/json</a></td>
+				<td class="repo"><a href="https://github.com/Microsoft/vscode-json-languageservice">github.com/Microsoft/vscode-json-languageservice</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="danger"></td>


### PR DESCRIPTION
I believe this is a correct change. The fact it is named json-**languageservice** instead of **language-server** has me doubt myself here.