### PR TITLE
Fixed typo in name for OCaml

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>
-				<th>O'Caml + ReasonML</th>
+				<th>OCaml + ReasonML</th>
 				<td><a href="https://github.com/freebroccolo">Darin Morrison</a></td>
 				<td class="repo"><a href="https://github.com/freebroccolo/ocaml-language-server">github.com/freebroccolo/ocaml-language-server</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>


### PR DESCRIPTION
OCaml is the preferred naming/capitalization convention, not O'Caml.

https://ocaml.org/

https://en.wikipedia.org/wiki/OCaml