### PR TITLE
Adding Gauge as a langauge server

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,6 +338,18 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>
+				<th>Gauge</th>
+				<td><a href="https://gauge.org/">Gauge</a></td>
+				<td class="repo"><a href="https://github.com/getgauge/gauge">github.com/getgauge/gauge</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			</tr>			
+			<tr>
 				<th>GLSL</th>
 				<td><a href="https://github.com/svenstaro">Sven-Hendrik Haase</a></td>
 				<td class="repo"><a href="https://github.com/svenstaro/glsl-language-server">github.com/svenstaro/glsl-language-server</a></td>


### PR DESCRIPTION
The latest release of gauge adds support for language server protocol https://github.com/getgauge/gauge/releases/tag/v0.9.6