### PR TITLE
Replace 'css-language-server' with 'vscode-css-languageserver-bin'

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,15 +291,15 @@
 			</tr>
       <tr> 
 				<th>CSS/LESS/SASS</th>
-				<td><a href="http://onivim.io/">Oni</a></td>
-				<td class="repo"><a href="https://github.com/onivim/css-language-server">github.com/onivim/css-language-server</a></td>
+				<td><a href="https://github.com/DeltaEvo">DeltaEvo</a></td>
+				<td class="repo"><a href="https://github.com/vscode-langservers/vscode-css-languageserver-bin">github.com/vscode-langservers/vscode-css-languageserver-bin</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="danger"></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="danger"></td>
-				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>
 				<th>D</th>


### PR DESCRIPTION
This PR replaces `css-language-server` it with `vscode-css-languageserver-bin`, which is better maintained and has a more complete of functionality (diagnostics support). FYI @DeltaEvo