### PR TITLE
Add success status to completion feature in scry

### DIFF
--- a/index.html
+++ b/index.html
@@ -728,7 +728,7 @@
 				<th>Crystal</th>
 				<td><a href="https://kofno.github.io/">Ryan L. Bell</a> and <a href="https://github.com/crystal-lang-tools/scry/graphs/contributors">contributors</a></td>
 				<td class="repo"><a href="https://github.com/crystal-lang-tools/scry">github.com/crystal-lang-tools/scry</a></td>
-				<td class="warning"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="warning"></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="warning"></td>


### PR DESCRIPTION
Hi  @attfarhan :smile: 

Currently auto-completion feature is working pretty well on scry:

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/6118156/37081344-05edea4e-21e1-11e8-8914-d767f8125aad.gif)

See: https://github.com/crystal-lang-tools/scry/pulls?q=is%3Apr+author%3Alaginha87

This PR updates completion status