### PR TITLE
change ruby language server to solargraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,6 +639,21 @@
 				<td></td>
 			</tr>
 			<tr>
+				<th>Ruby</th>
+				<td><a href="https://solargraph.org/">Fred Snyder</a></td>
+				<td class="repo"><a href="https://github.com/castwide/solargraph">github.com/castwide/solargraph</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="warning"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
+				<td class="danger"></td>
+				<td class="danger"></td>
+			</tr>
+			<tr>
 				<th>Rust</th>
 				<td><a href="https://github.com/nrc">Nick Cameron</a> and the Rust community</td>
 				<td class="repo"><a href="https://github.com/rust-lang-nursery/rls">github.com/rust-lang-nursery/rls</a></td>

--- a/index.html
+++ b/index.html
@@ -648,10 +648,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="warning"></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td class="danger"></td>
-				<td class="danger"></td>
-				<td class="danger"></td>
+				<td></td>
 			</tr>
 			<tr>
 				<th>Rust</th>


### PR DESCRIPTION
There was not much progress on mtsmfm/language_server-ruby recently. It was using rcodetools, a really outdated gem, which also was removed with no replacement. 

Meanwhile solargraph added almost every feature, which is obviously the reason, why you added this to sourcegraph. 
https://github.com/castwide/solargraph/issues/8