### PR TITLE
Update vim-lsc supporting workspace symbol search

### DIFF
--- a/index.html
+++ b/index.html
@@ -1052,7 +1052,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>


### PR DESCRIPTION
vim-lsc does allow searching for a symbol: `LSClientWorkspaceSymbol` or `gS`.
Reference: [Workspace Symbol Search](https://github.com/natebosch/vim-lsc/blob/master/README.md#workspace-symbol-search)
I've tested, it's working.