### PR TITLE
Update Kotlin implementation to active fork

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,8 +667,8 @@
 			</tr>
 			<tr>
 				<th>Kotlin</th>
-				<td><a href="https://github.com/georgewfraser">georgewfraser</a></td>
-				<td class="repo"><a href="https://github.com/georgewfraser/kotlin-language-server">github.com/georgewfraser/kotlin-language-server</a></td>
+				<td><a href="https://github.com/fwcd">fwcd</a></td>
+				<td class="repo"><a href="https://github.com/fwcd/KotlinLanguageServer">github.com/fwcd/KotlinLanguageServer</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>


### PR DESCRIPTION
The previously listed implementation (georgewfraser/kotlin-language-server) now mentions that development has been moved to fwcd/KotlinLanguageServer