### PR TITLE
Add Microsoft as Java language server contributor

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,7 +577,7 @@
 			</tr>
 			<tr>
 				<th>Java</th>
-				<td><a href="https://projects.eclipse.org/projects/eclipse.jdt.ls">Eclipse Foundation</a>, <a href="https://www.redhat.com">Red Hat</a></td>
+				<td><a href="https://projects.eclipse.org/projects/eclipse.jdt.ls">Eclipse Foundation</a>, <a href="https://www.redhat.com">Red Hat</a>, <a href="https://www.microsoft.com">Microsoft</a></td>
 				<td class="repo"><a href="https://github.com/eclipse/eclipse.jdt.ls">github.com/eclipse/eclipse.jdt.ls</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>


### PR DESCRIPTION
Microsoft is also an active contributor behind the Java language server project (eclipse.jdt.ls). Please check the link below to see the contribution distribution:
https://projects.eclipse.org/projects/eclipse.jdt.ls/who

This is to add Microsoft to the contributor list and acknowledge the effort.