### PR TITLE
added sticky table headers to the implementation tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,8 +229,8 @@
 		<a name="implementations-server"></a>
 		<h4>Language servers</h4>
 
-		<table class="table table-striped">
-			<thead class="sticky">
+		<table class="table table-striped sticky-header">
+			<thead>
 				<tr>
 					<th>Language</th>
 					<th>Maintainer&#160;&#160;&#160;&#160;&#160;&#160;</th>
@@ -1215,8 +1215,8 @@
 		<a name="implementations-client"></a>
 		<h4>LSP clients</h4>
 
-		<table class="table table-striped">
-			<thead class="sticky">
+		<table class="table table-striped sticky-header">
+			<thead>
 				<tr>
 					<th>Editor/client</th>
 					<th>Maintainer&#160;&#160;&#160;&#160;&#160;&#160;</th>

--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
 		<h4>Language servers</h4>
 
 		<table class="table table-striped">
-			<thead>
+			<thead class="sticky">
 				<tr>
 					<th>Language</th>
 					<th>Maintainer&#160;&#160;&#160;&#160;&#160;&#160;</th>
@@ -1216,7 +1216,7 @@
 		<h4>LSP clients</h4>
 
 		<table class="table table-striped">
-			<thead>
+			<thead class="sticky">
 				<tr>
 					<th>Editor/client</th>
 					<th>Maintainer&#160;&#160;&#160;&#160;&#160;&#160;</th>

--- a/style-additions.css
+++ b/style-additions.css
@@ -1,4 +1,21 @@
 td.repo {
-  word-wrap:break-word;
-  word-break:break-all;
+  word-wrap: break-word;
+  word-break: break-all;
+}
+
+.sticky {
+  position: sticky;
+  top: 0;
+  background-color: #fff;
+  z-index: 1;
+}
+
+.sticky>tr>td::after,
+.sticky>tr>th::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  border-bottom: 1px solid #ddd;
 }

--- a/style-additions.css
+++ b/style-additions.css
@@ -3,19 +3,25 @@ td.repo {
   word-break: break-all;
 }
 
-.sticky {
+.sticky-header>thead>tr>* {
   position: sticky;
-  top: 0;
+  position: -webkit-sticky;
+  position: -moz-sticky;
+  position: -ms-sticky;
+  position: -o-sticky;
+  top: 0px;
   background-color: #fff;
   z-index: 1;
+  border: none;
 }
-
-.sticky>tr>td::after,
-.sticky>tr>th::after {
+.sticky-header>tbody>tr:first-child>* {
+  border: none;
+}
+.sticky-header>thead>tr>*::after {
   content: '';
   position: absolute;
   left: 0;
   bottom: 0;
   width: 100%;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 2px solid #ddd;
 }


### PR DESCRIPTION
resolves #160.
Notes on cross-browser compatibility:
- I had to create the lower border of the thead > tds as in [this Stack Overflow answer](https://stackoverflow.com/a/45042852/6571327).
- `position: sticky` requires a `-webkit-` prefix on safari [[docs]](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Browser_compatibility), and chrome refuses to apply it to `<tr>` or `<thead>`, which requires a hack: using a border on `th::after` [[source]](https://stackoverflow.com/a/44004100/6571327).
I've tested this on the latest firefox, safari, and chrome.
