### PR TITLE
Update Dart to point to official SDK-supplied LSP server

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,8 +403,8 @@
 			</tr>
 			<tr>
 				<th>Dart</th>
-				<td><a href="https://github.com/natebosch">Nate Bosch</a></td>
-				<td class="repo"><a href="https://github.com/natebosch/dart_language_server">github.com/natebosch/dart_language_server</a></td>
+				<td><a href="https://dart.dev/">Dart Team</a></td>
+				<td class="repo"><a href="https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md">github.com/dart-lang/sdk</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>


### PR DESCRIPTION
The Dart SDK now ships with an LSP implementation supported by the Dart Team. The original project by @natebosch is [no longer being maintained](https://github.com/natebosch/dart_language_server/blob/master/README.md) as a result.