### PR TITLE
Add openVALIDATION to the list of language server implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,6 +806,18 @@
 				<td></td>
 			</tr>
 			<tr>
+				<th>openVALIDATION</th>
+				<td><a href="http://openvalidation.io/">openVALIDATION</a></td>
+				<td class="repo"><a href="https://github.com/openvalidation/ov-language-server">github.com/openvalidation/ov-language-server</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td></td>
+			</tr>
+			<tr>
 				<th>PHP</th>
 				<td><a href="https://github.com/felixfbecker">Felix Becker</a></td>
 				<td class="repo"><a href="https://github.com/felixfbecker/php-language-server">github.com/felixfbecker/php-language-server</a></td>


### PR DESCRIPTION
This commit adds [openVALIDATION](https://github.com/openvalidation/openvalidation) to the list.