### PR TITLE
Add TypeFox's Typescript language server, wrapping tsserver

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,6 +1217,22 @@
 				</td>
 			</tr>
 			<tr>
+				<th>TypeScript</th>
+				<td><a href="https://www.typefox.io/">TypeFox</a></td>
+				<td class="repo"><a href="https://github.com/theia-ide/typescript-language-server">github.com/theia-ide/typescript-language-server</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td>
+					<ul class="list-unstyled text-nowrap">
+						<li>Wraps <a href="https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29">tsserver</a></li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
 				<th>XML</th>
 				<td><a href="https://ibm.com/">IBM</a></td>
 				<td class="repo"><a href="https://github.com/microclimate-devops/xml-language-server">github.com/microclimate-devops/xml-language-server</a></td>


### PR DESCRIPTION
Just found this, seems to work, find references match with Visual Studio Code when used from NeoVim + LanguageClient-neovim