### PR TITLE
Add gopls to the language server list

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,6 +648,18 @@
 				</td>
 			</tr>
 			<tr>
+				<th>Go</th>
+				<td><a href="https://golang.org/project/">Go Team</a></td>
+				<td class="repo"><a href="https://github.com/golang/tools/tree/master/gopls">github.com/golang/tools/tree/master/gopls</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td></td>
+			</tr>
+			<tr>
 				<th>GraphQL</th>
 				<td><a href="https://github.com/graphql">GraphQL Foundation</a></td>
 				<td class="repo"><a href="https://github.com/graphql/graphiql">github.com/graphql/graphiql</a></td>


### PR DESCRIPTION
I propose the addition of [gopls](https://github.com/golang/tools/tree/master/gopls), the official LSP client for the Go programming language. Currently, the “Language Servers” table suggests people to install [go-langserver](https://github.com/sourcegraph/go-langserver), a project from Sourcegraph that has been [deprecated since Dec 13, 2018
](https://github.com/sourcegraph/go-langserver/commit/3c8059f14a3aa6cfe9d9388cd7fbb5cbb4726675#diff-04c6e90faac2675aa89e2176d2eec7d8).