### PR TITLE
Add not applicable color code to mark unnecessary features

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,10 @@
 						<td class="danger"></td>
 						<td>Not implemented</td>
 					</tr>
+					<tr>
+						<td class="info"></td>
+						<td>Not applicable</td>
+					</tr>
 				</table>
 			</div>
 		</div>


### PR DESCRIPTION
Some clients in the "Language Servers" table do not need to implement all the functionality mentioned in the LSP documentation. For example, the JSON client does not need to implement "Jump to Definition" because people cannot implement functions in JSON files.

Coloring these table cells in red gives the impression that the client is not fully compliant with the protocol. I propose to color these cells blue to indicate these features do not require an implementation.

---

<img width="772" alt="Screen Shot 2020-02-28 at 15 47 05" src="https://user-images.githubusercontent.com/1933999/75595516-9f49a800-5a41-11ea-8ce6-d833f3468ab4.png">
