### PR TITLE
Add rust-analyzer language server

### DIFF
--- a/index.html
+++ b/index.html
@@ -1161,6 +1161,22 @@
 				</td>
 			</tr>
 			<tr>
+				<th>Rust</th>
+				<td><a href="https://github.com/matklad">Aleksey Kladov</a> and contributors</td>
+				<td class="repo"><a href="https://github.com/rust-analyzer/rust-analyzer">github.com/rust-analyzer/rust-analyzer</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td>
+					<ul class="list-unstyled text-nowrap">
+						<li>Automatic dependency management<sup><a href="#dependencyFootnote">1</a></sup></li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
 				<th>Scala</th>
 				<td><a href="https://github.com/dragos">Iulian Dragos</a></td>
 				<td class="repo"><a href="https://github.com/dragos/dragos-vscode-scala">github.com/dragos/dragos-vscode-scala</a></td>


### PR DESCRIPTION
I am not sure what the [SymbolDescriptor](https://github.com/sourcegraph/language-server-protocol/blob/master/extension-symbol-descriptor.md) extension is, so I don't know if rust-analyzer implements it. cc @matklad

There are several additional capabilities that rust-analyzer has that I haven't mentioned.

Fixes #194