### PR TITLE
Remove deprecated Elixir entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,18 +546,6 @@
 				<td></td>
 			</tr>
 			<tr>
-				<th>Elixir</th>
-				<td><a href="https://github.com/JakeBecker">Jake Becker</a></td>
-				<td class="repo"><a href="https://github.com/JakeBecker/elixir-ls">github.com/JakeBecker/elixir-ls</a></td>
-				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td class="danger"></td>
-				<td class="danger"></td>
-				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td></td>
-			</tr>
-			<tr>
 				<th>Elm</th>
 				<td><a href="https://github.com/elm-tooling">Elm Tooling</a></td>
 				<td class="repo"><a href="https://github.com/elm-tooling/elm-language-server">github.com/elm-tooling/elm-language-server</a></td>


### PR DESCRIPTION
The project has been moved and is now maintained by https://github.com/elixir-lsp/elixir-ls, so the duplicate entry is no longer necessary.