### PR TITLE
Added Delphi and C++Builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,6 +482,23 @@
 				<td></td>
 			</tr>
 			<tr>
+				<th>Delphi</th>
+				<td><a href="https://www.embarcadero.com/">Embarcadero</a></td>
+				<td class="repo">Proprietary (<a href="http://docwiki.embarcadero.com/RADStudio/en/Code_Insight_Reference">DelphiLSP</a>)</td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
+				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td>
+					<ul class="list-unstyled text-nowrap">
+						<li>No arbitrary code execution<sup><a href="#arbitraryExecutionFootnote">2</a></sup></li>
+						<li>Multi-process architecture</li>
+					</ul>				
+				</td>
+			</tr>
+			<tr>
 				<th>Dockerfile</th>
 				<td><a href="https://github.com/rcjsuen">Remy Suen</a></td>
 				<td class="repo"><a href="https://github.com/rcjsuen/dockerfile-language-server-nodejs">github.com/rcjsuen/dockerfile-language-server-nodejs</a></td>
@@ -1595,6 +1612,28 @@
 			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			</tr>
+			<tr>
+			    <th>C++Builder</th>
+			    <td><a href="https://www.embarcadero.com/">Embarcadero</a></td>
+			    <td class="repo"><a href="https://www.embarcadero.com/products/cbuilder">Proprietary</a></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="danger"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="danger"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			</tr>
+			<tr>
+			    <th>Delphi</th>
+			    <td><a href="https://www.embarcadero.com/">Embarcadero</a></td>
+			    <td class="repo"><a href="https://www.embarcadero.com/products/delphi">Proprietary</a></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="danger"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="danger"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>


### PR DESCRIPTION
Delphi and C++Builder are sibling products which use same IDE, RAD Studio, and both support LSP. C++Builder uses a modified version of cquery, so only the IDE has been added. Delphi has its own server, so both the IDE and server are listed here. Both products are closed source: links to go product or documentation pages, not a source repo.

They have been added in alphabetical order in each table.