### PR TITLE
Add citation-langserver

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="danger"></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
-				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+                                <td class="danger"></td>
 			</tr>
 			<tr>
 				<th>C#</th>

--- a/index.html
+++ b/index.html
@@ -321,6 +321,17 @@
 				<td></td>
 			</tr>
 			<tr>
+				<th>BibTeX</th>
+				<td><a href="https://andrew.pilsch.com">Andrew Pilsch</a></td>
+				<td class="repo"><a href="https://github.com/oncomouse/citation-langserver">https://github.com/oncomouse/citation-langserver</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			</tr>
+			<tr>
 				<th>C#</th>
 				<td><a href="http://www.omnisharp.net/">OmniSharp</a></td>
 				<td class="repo"><a href="https://github.com/OmniSharp/omnisharp-node-client/blob/master/languageserver">github.com/OmniSharp/omnisharp-node-client/blob/master/languageserver</a></td>


### PR DESCRIPTION
Please consider adding the citation-langserver, which provides language server support for authors who use BibTeX to manage citations.

I wasn't sure if the language for this one should be BibTeX or something else, as it doesn't actually support *editing* BibTeX files, so much as it supports the use of BibTeX files in languages such as Markdown, LaTeX, and reStructuredText. If it makes more sense to have a different language, I can amend the request.