### PR TITLE
Replace unmaintained palantir LS with active fork

### DIFF
--- a/index.html
+++ b/index.html
@@ -1223,7 +1223,7 @@
 			</tr>
 			<tr>
 				<th>Python</th>
-				<td><a href="https://github.com/python-lsp/">Palantir</a></td>
+				<td><a href="https://github.com/python-lsp/">python-lsp</a></td>
 				<td class="repo"><a href="https://github.com/python-lsp/python-lsp-server">github.com/python-lsp/python-lsp-server</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>

--- a/index.html
+++ b/index.html
@@ -1223,8 +1223,8 @@
 			</tr>
 			<tr>
 				<th>Python</th>
-				<td><a href="http://www.palantir.com/">Palantir</a></td>
-				<td class="repo"><a href="https://github.com/palantir/python-language-server">github.com/palantir/python-language-server</a></td>
+				<td><a href="https://github.com/python-lsp/">Palantir</a></td>
+				<td class="repo"><a href="https://github.com/python-lsp/python-lsp-server">github.com/python-lsp/python-lsp-server</a></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>


### PR DESCRIPTION
The palantir python language server [is unmaintained](https://github.com/palantir/python-language-server/issues/934#issuecomment-836776973). The maintainers, who are also the maintainers of the Spyder IDE, had their access to the palantir LS repo revoked, and have since created this fork at python-lsp to continue development and maintenance.