### PR TITLE
Add codemirror-languageserver for CodeMirror 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -1997,6 +1997,17 @@
 			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>
+			    <th>CodeMirror 6</th>
+			    <td><a href="https://github.com/hjr265">Mahmud Ridwan</a></td>
+			    <td class="repo"><a href="https://github.com/FurqanSoftware/codemirror-languageserver">github.com/FurqanSoftware/codemirror-languageserver</a></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="warning"></td>
+			    <td class="warning"></td>
+			    <td class="warning"></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			</tr>
+			<tr>
 			    <th>Emacs</th>
 			    <td><a href="https://github.com/cmr">Corey Richardson</a></td>
 			    <td class="repo"><a href="https://github.com/sourcegraph/emacs-lsp">github.com/sourcegraph/emacs-lsp</a></td>


### PR DESCRIPTION
I have added the row for CodeMirror 6 (similar to and below CodeMirror, under "Work in progress" section):

![image](https://user-images.githubusercontent.com/348107/120312361-72e2a280-c2fa-11eb-884a-064384c78d43.png)

Closes #246 