### PR TITLE
Update Language Server Protocol specification link

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 			features like auto complete, go to definition, find all references and alike into the tool
 		</blockquote>
 		<p>
-			– <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/">official Language Server Protocol specification</a>
+			– <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/">official Language Server Protocol specification</a>
 		</p>
 		<p>
 			The LSP was created by Microsoft to define a common language for programming language analyzers to speak. Today, several


### PR DESCRIPTION
Make Language Server Protocol specification link to current specification instead of version 3.14