### PR TITLE
Add Helix to the list of LSP clients

### DIFF
--- a/index.html
+++ b/index.html
@@ -1884,6 +1884,17 @@
 			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 			</tr>
 			<tr>
+			    <th>Helix</th>
+			    <td><a href="https://github.com/archseer">Blaž Hrastnik</a></td>
+			    <td class="repo"><a href="https://github.com/helix-editor/helix">https://github.com/helix-editor/helix</a></td>
+			    <td class="danger"></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			    <td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+			</tr>
+			<tr>
 			    <th>IntelliJ / JetBrains IDEs</th>
 			    <td><a href="https://github.com/ballerina-platform">Ballerina-Lang Team</a></td>
 			    <td class="repo"><a href="https://github.com/ballerina-platform/lsp4intellij">github.com/ballerina-platform/lsp4intellij</a></td>


### PR DESCRIPTION
Adds the [Helix](https://github.com/helix-editor/helix) editor to the list of the LSP clients.

It works fine for the rust-analyzer LSP server, and should be fine for other langauges as well.