### PR TITLE
Fix a typo involving unnecessary "where"

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
 		<p>
 			Microsoft currently maintains a <a href="https://microsoft.github.io/language-server-protocol/implementors/servers/">parallel list of language server implementations</a> in the core LSP repository. This site is designed to operate alongside Microsoft's list by providing more information
 			about the capabilities of language servers and LSP clients, informing users which features to expect when
-			they download and install a new language server and/or client, and communicating where to open-source contributors where help is needed.
+			they download and install a new language server and/or client, and communicating to open-source contributors where help is needed.
 		</p>
 		<br/>
 		<h4>Qualifications:</h4>


### PR DESCRIPTION
"where" is already in the phrase at the end, "where help is needed"