### PR TITLE
Python: add jedi language server

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,12 +414,12 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td>
-				    <ul class="list-unstyled text-nowrap">					  
+				    <ul class="list-unstyled text-nowrap">
 					<li>Outline view</li>
-					<li>Javascript expression test evaluation</li>					    
+					<li>Javascript expression test evaluation</li>
 					<li>Preview of workflow graph</li>
 					<li>Preview of linked files</li>
-				    </ul>				
+				    </ul>
 				</td>
 			</tr>
 			 <tr>
@@ -527,7 +527,7 @@
 					<ul class="list-unstyled text-nowrap">
 						<li>No arbitrary code execution<sup><a href="#arbitraryExecutionFootnote">2</a></sup></li>
 						<li>Multi-process architecture</li>
-					</ul>				
+					</ul>
 				</td>
 			</tr>
 			<tr>
@@ -1074,7 +1074,7 @@
 				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
 				<td></td>
 			</tr>
-			
+
 			<tr>
 				<th>Perl</th>
 				<td><a href="https://github.com/richterger/">Gerald Richter</a></td>

--- a/index.html
+++ b/index.html
@@ -1329,6 +1329,18 @@
 				<td></td>
 			</tr>
 			<tr>
+				<th>Python</th>
+				<td><a href="https://samroeca.com/">Samuel Roeca</a></td>
+				<td class="repo"><a href="https://github.com/pappasam/jedi-language-server">github.com/pappasam/jedi-language-server</a></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td></td>
+			</tr>
+			<tr>
 				<th>Q#</th>
 				<td><a href="https://github.com/microsoft/qsharp-compiler/graphs/contributors">Microsoft</a></td>
 				<td class="repo"><a href="https://github.com/microsoft/qsharp-compiler">github.com/microsoft/qsharp-compiler</a></td>


### PR DESCRIPTION
Adds https://github.com/pappasam/jedi-language-server as a Python language server implementation.