### PR TITLE
Add Snyk Language Server (https://github.com/snyk/snyk-ls)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1622,6 +1622,19 @@
 				<td>Code Formatting, Signature Help</td>
 			</tr>
 			<tr>
+				<th>Snyk</th>
+				<td><a href="https://snyk.io">Snyk</a></td>
+				<td class="repo"><a href="https://github.com/snyk/snyk-ls">https://github.com/snyk/snyk-ls</a></td>
+				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td class="danger"></td>
+				<td class="danger"></td>
+				<td class="danger"></td>
+				<td class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></td>
+				<td>Automatic download of Snyk CLI with custom notification of path to binary, diagnostic workspace scans over all workspace folders on startup. Supports Snyk Code,
+					Snyk IaC and Snyk Open Source. Authentication to Snyk is supported and token returned via custom notification.</td>
+			</tr>
+			<tr>
 				<th>Swift &amp; C-family</th>
 				<td><a href="https://github.com/apple">Apple Inc</a></td>
 				<td class="repo"><a href="https://github.com/apple/sourcekit-lsp">github.com/apple/sourcekit-lsp</a></td>


### PR DESCRIPTION
This adds an entry for the newly open-sourced and released Snyk Language Server (https://snyk.io/blog/snyk-security-using-language-server-protocol/?utm_campaign=Snyk-LSP-2022&utm_medium=Social&utm_source=Twitter-Organic&utm_content=snyk-security-using-language-server-protocol).

![image](https://user-images.githubusercontent.com/20150761/191715339-80d21d25-f566-4005-bbdd-3c97db36570e.png)
