### PR TITLE
Switch to the Vala language server

### DIFF
--- a/index.html
+++ b/index.html
@@ -3424,10 +3424,10 @@
         <tr>
           <th>Vala</th>
           <td>
-            <a href="https://wiki.gnome.org/Projects/Vala">GNOME Foundation</a>
+            <a href="https://github.com/vala-lang">vala-lang</a>
           </td>
           <td class="repo">
-            <a href="https://gitlab.gnome.org/esodan/gvls">GNOME's GitLab Instance</a>
+            <a href="https://github.com/vala-lang/vala-language-server">https://github.com/vala-lang/vala-language-server</a>
           </td>
           <td class="success">
             <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
@@ -3441,18 +3441,13 @@
           <td class="success">
             <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
           </td>
-          <td class="danger"></td>
           <td class="success">
             <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
           </td>
-          <td>
-            <ul class="list-unstyled text-nowrap">
-              <li>No arbitrary code execution <sup>
-                  <a href="#arbitraryExecutionFootnote">2</a>
-                </sup>
-              </li>
-            </ul>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
           </td>
+          <td></td>
         </tr>
         <tr>
           <th>Veryl</th>


### PR DESCRIPTION
GVls is now a deprecated language server: 

See: https://gitlab.gnome.org/GNOME/gnome-builder/-/issues/1690#note_1500380

Additionally I removed the note that there is no arbitrary code execution, as it is wrong. As soon as you open the project, it is build => Buildsystem is executed => Code Execution