### PR TITLE
Mark Sourcegraph's go-langserver as Archived

### DIFF
--- a/index.html
+++ b/index.html
@@ -1306,7 +1306,9 @@
           <td></td>
         </tr>
         <tr>
-          <th>Go</th>
+          <th>Go
+            <span class="label label-warning">Archived</span>
+	  </th>
           <td>
             <a href="https://sourcegraph.com/">Sourcegraph</a>
           </td>


### PR DESCRIPTION
[GitHub repo](https://github.com/sourcegraph/go-langserver) is read-only since Oct 12, 2022.