### PR TITLE
Extend Cucumber Language Server features

### DIFF
--- a/index.html
+++ b/index.html
@@ -655,16 +655,25 @@
             <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
           </td>
           <td class="danger"></td>
-          <td class="danger"></td>
-          <td class="info"></td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
           <td class="danger"></td>
           <td class="success">
             <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
           </td>
           <td>
             <ul class="list-unstyled text-nowrap">
+              <li>Autocomplete steps</li>
+              <li>Go to step definition</li>
+              <li>Generate step definition from snippets</li>
               <li>Syntax highlighting (semantic tokens)</li>
+              <li>Diagnostics for undefined steps</li>
               <li>Formatting</li>
+              <li>Outline view</li>
             </ul>
           </td>
         </tr>


### PR DESCRIPTION
Features implemented by the [Cucumber Language Server](https://github.com/cucumber/language-server) are missing (see [Cucumber Language Service](https://github.com/cucumber/language-service) and [Cucumber Visual Studio Code extension](https://github.com/cucumber/vscode)).

Ticking the boxes as `Implemented` for:

- `Jump to def` - 'Go to step definition' is implemented to navigate from a _gherkin step_ to a _step definition_ where it is defined
- `Workspace symbols` - as the server offers a document outline that can be used for navigation in Visual Studio Code for example