### PR TITLE
Add ecode to the list of editors supporting LSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -4245,6 +4245,33 @@
           </td>
         </tr>
         <tr>
+          <th>ecode</th>
+          <td>
+            <a href="https://github.com/SpartanJ">Martín Lucas Golini</a>
+          </td>
+          <td class="repo">
+            <a href="https://github.com/SpartanJ/ecode">github.com/SpartanJ/ecode</a>
+          </td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
+        </tr>
+        <tr>
           <th>Emacs</th>
           <td>
             <a href="https://github.com/vibhavp">Vibhav Pant</a>


### PR DESCRIPTION
Hi, I'm Martín the author of [ecode](https://github.com/SpartanJ/ecode).
I would like, if possible, to add ecode to the list of editors supporting LSP.
ecode implementation currently supports all the listed features.

ecode is already listed in https://microsoft.github.io/language-server-protocol/implementors/tools/

Thanks!