### PR TITLE
Update row for codemirror-languageserver (CodeMirror 6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5170,7 +5170,9 @@
           <td class="success">
             <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
           </td>
-          <td class="warning"></td>
+          <td class="success">
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+          </td>
           <td class="warning"></td>
           <td class="warning"></td>
           <td class="success">


### PR DESCRIPTION
Mark "Jump to def" as supported for codemirror-languageserver (CodeMirror 6). The library now supports "Go to Definition, Declaration, and Type Definition" as listed in its README.

https://github.com/FurqanSoftware/codemirror-languageserver#readme