### PR TITLE
Update Kate repository URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -4679,7 +4679,7 @@
             <a href="https://kate-editor.org">Kate Team</a>
           </td>
           <td class="repo">
-            <a href="https://invent.kde.org/kde/kate">invent.kde.org/kde/kate</a>
+            <a href="https://invent.kde.org/utilities/kate">invent.kde.org/utilities/kate</a>
           </td>
           <td class="success">
             <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>


### PR DESCRIPTION
Clicking old link shows this:
<img width="1504" height="388" alt="image" src="https://github.com/user-attachments/assets/181d53a1-0d4a-4a26-9998-5b8e241be0a2" />

This updates the link accordingly.